### PR TITLE
Cutting 3.2.9 release for semantic versioning of the SDK.

### DIFF
--- a/SpotzSDK.podspec
+++ b/SpotzSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 			Copyright 2019 Localz Pty Ltd.
 			LICENSE
 	}
-	s.version = '3.3.3'
+	s.version = '3.2.9'
 	s.summary = 'iOS library for Localz Platform'
 	s.homepage = 'http://localz.com'
 	s.author = { 'Localz Pty Ltd' => 'info@localz.com' }
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
 	s.requires_arc = true
 	s.source = { :git => 'https://github.com/localz/Spotz3-iOS-SDK.git' }
 	s.frameworks = 'CoreLocation','SystemConfiguration','Foundation'
-	s.dependency 'YapDatabase/Standard/Core'
+	s.dependency 'YapDatabase/Standard/Core', '3.1.4'
 end

--- a/SpotzSDK/SpotzSDK.framework/Versions/A/Headers/SpotzSDK.h
+++ b/SpotzSDK/SpotzSDK.framework/Versions/A/Headers/SpotzSDK.h
@@ -110,14 +110,14 @@
 
 /**
  * Returns true if device is inside the spot
- * @param name Spot's id
+ * @param spotId Spot's id
  * @return true if inside, false if outside or not yet detected
  */
 - (BOOL) isInsideSpotWithId:(nonnull NSString *)spotId;
 
 /**
  * Returns true if device is inside a spot with the given site ID
- * @param name Site ID
+ * @param siteId Site ID
  * @return true if inside, false if outside or not yet detected
  */
 - (BOOL) isInsideSpotAtSiteId:(nonnull NSString *)siteId;
@@ -240,7 +240,7 @@
 
 /**
  * Returns the spotz events enabled flag
- * @param true if enabled, false if not
+ * @return true if enabled, false if not
  */
 - (BOOL) isSpotzEventsEnabled;
 

--- a/SpotzSDK/SpotzSDK.framework/Versions/A/Headers/SpotzSDK.h
+++ b/SpotzSDK/SpotzSDK.framework/Versions/A/Headers/SpotzSDK.h
@@ -50,6 +50,12 @@
 + (void) initWithAppId:(nonnull NSString *)appId appKey:(nonnull NSString *)appKey delegate:(nullable id)delegate config:(nullable NSDictionary *)config;
 
 /**
+ *  Returns SpotzSDK version.
+ *  @return Returns the current SpotzSDK version
+*/
++ (nonnull NSString *) sdkVersion;
+
+/**
  *  Initialises location services and Spots. This must be run to register all Spots. We recommend this to be called at the point where you are ready to prompt user to enable location services (if not yet enabled previously). This will also download the closest site's data
  */
 - (void) startSpotz;
@@ -104,14 +110,14 @@
 
 /**
  * Returns true if device is inside the spot
- * @param spotId Spot's id
+ * @param name Spot's id
  * @return true if inside, false if outside or not yet detected
  */
 - (BOOL) isInsideSpotWithId:(nonnull NSString *)spotId;
 
 /**
  * Returns true if device is inside a spot with the given site ID
- * @param siteId Site ID
+ * @param name Site ID
  * @return true if inside, false if outside or not yet detected
  */
 - (BOOL) isInsideSpotAtSiteId:(nonnull NSString *)siteId;
@@ -162,15 +168,6 @@
 - (void) stopSpotz;
 
 /**
- * Monitor a whitelist of site IDs. This will replace any existing site IDs being monitored.
- * This is only available when the SDK is started in static monitoring mode.
- * To start the SDK in static monitoring mode use the initalisation config `@{ @"staticMonitoring":true }`
- *
- * @param siteIds   An array of all siteIds to be monitored.
- */
-- (void) monitorSiteIds:(nonnull NSArray<NSString *>*)siteIds;
-
-/**
  *  Returns the device ID assigned to this device
  *
  *  @return The Spotz's device ID assigned to this device
@@ -192,6 +189,7 @@
  *  Associates the current device with a custom identity. Note that if the app is reinstalled, deviceId will need to be re-associated with the identity.
  *
  *  @param identityId identity to be assigned to this device e.g. customerId/token/email
+ *  @param attributes additional information to be associated with this device. Useful when passing additional info to third party extensions.
  *  @param completion A block object to be executed when the task finishes successfully. This block has no return value and takes one argument: the error object describing the error that occurred.
  */
 - (void) identity:(nonnull NSString *)identityId completion:(void(^ _Nullable)(NSError * _Nullable error))completion;
@@ -242,7 +240,7 @@
 
 /**
  * Returns the spotz events enabled flag
- * @return true if enabled, false if not
+ * @param true if enabled, false if not
  */
 - (BOOL) isSpotzEventsEnabled;
 


### PR DESCRIPTION
This binary is from 3.2.8.x branch that we created to release a stable build. There's been no code change since the last release of 3.2.8.3.
Following semantic versioning standards and cutting a new release - 3.2.9